### PR TITLE
Update Terraform workflows to use environment-specific variable files

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -57,4 +57,4 @@ jobs:
           -backend-config="container_name=${{ vars.BACKEND_STORAGE_CONTAINER_NAME }}" \
           -backend-config="key=${{ vars.APPLICATION_NAME }}-${{ vars.ENVIRONMENT_NAME }}"
           
-        terraform apply -auto-approve
+        terraform apply -var-file=_${{ vars.ENVIRONMENT_NAME }}.tfvars -auto-approve

--- a/.github/workflows/terraform-destroy.yaml
+++ b/.github/workflows/terraform-destroy.yaml
@@ -57,4 +57,4 @@ jobs:
           -backend-config="container_name=${{ vars.BACKEND_STORAGE_CONTAINER_NAME }}" \
           -backend-config="key=${{ vars.APPLICATION_NAME }}-${{ vars.ENVIRONMENT_NAME }}"
           
-        terraform destroy -auto-approve
+        terraform destroy -var-file=_${{ vars.ENVIRONMENT_NAME }}.tfvars -auto-approve


### PR DESCRIPTION
This pull request includes updates to the Terraform workflows to ensure the correct variable files are used during the apply and destroy processes. The most important changes include modifications to the `terraform-apply.yaml` and `terraform-destroy.yaml` workflow files.

Updates to Terraform workflows:

* [`.github/workflows/terraform-apply.yaml`](diffhunk://#diff-3b9bba76a5ffb1ff5dce644ab6f9f94b4c31bf429c44cd14ad8f40ab0cac9067L60-R60): Added the `-var-file=_${{ vars.ENVIRONMENT_NAME }}.tfvars` argument to the `terraform apply` command to specify the environment-specific variable file.
* [`.github/workflows/terraform-destroy.yaml`](diffhunk://#diff-530bc4b4a0f81d207c4a26b754de9ff0905e2d9f2a144ade59e7520f8c873438L60-R60): Added the `-var-file=_${{ vars.ENVIRONMENT_NAME }}.tfvars` argument to the `terraform destroy` command to specify the environment-specific variable file.