### PR TITLE
Add GitHub Actions workflow for building and pushing frontend Docker image

### DIFF
--- a/.github/workflows/docker-build-push-frontend.yaml
+++ b/.github/workflows/docker-build-push-frontend.yaml
@@ -1,0 +1,31 @@
+name: Frontend Build and Push
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Check out code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Log in to Azure
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ vars.ACR_ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      # Step 3: Build and Push Frontend Image
+      - name: Build and Push Frontend Image
+        run: |
+          docker build -t ${{ vars.ACR_NAME }}.azurecr.io/frontend:${{ github.sha }} ./frontend
+          docker push ${{ vars.ACR_NAME }}.azurecr.io/frontend:${{ github.sha }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and push process for the frontend application. The workflow is triggered by pushes to the main branch that affect files in the `frontend` directory.

Key changes include:

* [`.github/workflows/docker-build-push-frontend.yaml`](diffhunk://#diff-af215dc16f5bd06f3033bee51975698ff527b9d9f50799f2bb5683072414d0c9R1-R31): Added a new workflow configuration file to build and push the frontend Docker image to Azure Container Registry. This workflow includes steps for checking out the code, logging into Azure, and building and pushing the Docker image.